### PR TITLE
lintconf.yaml now matches stable catalog's file content.

### DIFF
--- a/.github/workflows/notify-api.yml
+++ b/.github/workflows/notify-api.yml
@@ -12,6 +12,6 @@ on:
 jobs:
   notify:
     name: Notify
-    uses: slateci/github-actions/.github/workflows/slate-updateapps.yml@v1
+    uses: slateci/github-actions/.github/workflows/slate-updateapps.yml@v2
     secrets:
       slate_api_token: "${{ secrets.SLATE_API_TOKEN }}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,4 +8,4 @@ on:
 jobs:
   test:
     name: Test Helm Charts
-    uses: slateci/github-actions/.github/workflows/chart-repo-test.yml@v1
+    uses: slateci/github-actions/.github/workflows/chart-repo-test.yml@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,6 @@ on:
 jobs:
   helm-repo:
     name: Helm Repo
-    uses: slateci/github-actions/.github/workflows/chart-repo-release.yml@v1
+    uses: slateci/github-actions/.github/workflows/chart-repo-release.yml@v2
     secrets:
       gh_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/lintconf.yaml
+++ b/lintconf.yaml
@@ -1,41 +1,30 @@
+# Based on the relaxed configuration described on https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration .
+
+extends: default
+
 rules:
   braces:
-    min-spaces-inside: 0
-    max-spaces-inside: 0
-    min-spaces-inside-empty: -1
-    max-spaces-inside-empty: -1
-  brackets:
-    min-spaces-inside: 0
-    max-spaces-inside: 0
-    min-spaces-inside-empty: -1
-    max-spaces-inside-empty: -1
-  colons:
-    max-spaces-before: 0
-    max-spaces-after: 1
-  commas:
-    max-spaces-before: 0
-    min-spaces-after: 1
-    max-spaces-after: 1
-  comments:
-    require-starting-space: true
-    min-spaces-from-content: 2
-  document-end: disable
-  document-start: disable           # No --- to start a file
-  empty-lines:
-    max: 2
-    max-start: 0
-    max-end: 0
-  hyphens:
-    max-spaces-after: 1
-  indentation:
-    spaces: consistent
-    indent-sequences: whatever      # - list indentation will handle both indentation and without
-    check-multi-line-strings: false
-  key-duplicates: enable
-  line-length: disable              # Lines can be any length
-  new-line-at-end-of-file: enable
-  new-lines:
-    type: unix
-  trailing-spaces: enable
-  truthy:
     level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  trailing-spaces: disable
+  truthy: disable


### PR DESCRIPTION
See #42 for more details.