### PR TITLE
Migrate Telegraf chart and update deprecated image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-charts/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+charts/.DS_Store

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: telegraf
+version: 0.6.0
+appVersion: 1.17.0
+description: "Deploys an SNMP monitoring service using Telegraf."

--- a/charts/telegraf/README.md
+++ b/charts/telegraf/README.md
@@ -1,0 +1,114 @@
+# Telegraf SNMP Monitoring
+
+Application Name (in catalog): `telegraf`
+
+Application Version: `0.5.0`
+
+
+## Description
+
+This application uses Telegraf to pull [SNMP](http://www.net-snmp.org/) metrics from user-specifiable hosts.
+Metrics are then pushed to a time-series database. This database endpoint can also be configured by the user.
+Beyond general SNMP configuration options, this application also contains features to easily report a standard set of metrics to Indiana University's Global Research Network Operations Center ([GlobalNOC, or GRNOC](https://globalnoc.iu.edu/)).
+
+
+## Installation
+
+This application is quite simple to install. First, retrieve and locally store the default configuration file with this command: 
+
+```bash
+slate app get-conf telegraf > telegraf.yaml
+```
+
+Next, modify the configuration file with your preferred editor to ensure appropriate configuration. A guide to this can be found [here](https://slateci.io/blog/telegraf-monitoring.html).
+
+Then, if you are writing to GlobalNOC's database, create a SLATE secret containing your database password.
+This is done with the following command:
+```bash
+slate secret create --group <slate_group> --cluster <slate_cluster> --from-literal password=<your_password> <secret_name>
+```
+
+Finally, install the app with your custom configuration onto a SLATE cluster.
+Use a command that looks something like this: 
+
+```bash
+slate app install telegraf --group <group_name> --cluster <cluster> --conf telegraf.yaml
+```
+
+*Note that this application does not make sense to deploy without SNMP-enabled hosts to monitor, and a database endpoint to send metrics to.*
+
+
+## System Requirements
+
+No special compute resources are required for this application.
+
+
+## Network Requirements
+
+This application will utilize ports 161 and 162 for SNMP messages.
+Additionally, a user-configurable database output port will be exposed.
+
+This service does not require its own IP or a load balancer.
+
+
+## Storage Requirements
+
+Telegraf on SLATE requires no persistent storage.
+However, most use cases will require a separate database to send metrics to.
+
+
+## Statefulness
+
+This application operates without any state, and is not dependent on any other services within SLATE.
+
+
+## Privilege Requirements
+
+No special privilege requirements are necessary.
+
+
+## Monitoring and Logging
+
+There are no special monitoring considerations.
+
+
+## Multiple Versions
+
+It is not necessary to support multiple versions.
+
+
+## Testing
+
+No testing package is included.
+However, [this post](https://slateci.io/blog/telegraf-monitoring.html) contains more information about ways to test the Telegraf application.
+
+
+## Configurable Parameters
+
+The following table lists the configurable parameters of the Telegraf monitoring application and their default values.
+
+|           Parameter           |           Description           |           Default           |
+|-------------------------------|---------------------------------|-----------------------------|
+|`Instance`| Optional string to differentiate SLATE experiment instances |`""`|
+|`writeToStdout`| Optionally write to stdout in container |`true`|
+|`collectionInterval`| Data collection interval |`5s`|
+|`collectionJitter`| Data jitter interval |`10s`|
+|`flushInterval`| Output flush interval |`15s`|
+|`flushJitter`| Output jitter interval |`10s`|
+|`grnocOutput.enabled`| Whether to write to GlobalNOC database |`true`|
+|`grnocOutput.hostname`| Database endpoint |`tsds.hostname.net`|
+|`grnocOutput.username`| Database username |`tsds username`|
+|`grnocOutput.passwordSecretName`| GlobalNOC database password secret name |`tsds-password-secret`|
+|`targets.hostGroup.community`| Community string of `hostGroup` |`public`|
+|`targets.hostGroup.timeout`| SNMP timeout length of `hostGroup` |`15s`|
+|`targets.hostGroup.retries`| Number of retries to attempt for `hostGroup` |`2`|
+|`targets.hostGroup.hosts`| Hosts to monitor |`127.0.0.1:161`|
+|`targets.hostGroup.counter64bit`| Type of SNMP counter on host machine |`false`|
+|`targets.hostGroup.oids`| SNMP OIDs to poll |*telegraf configuration monitoring system uptime*|
+|`influxOutput.enabled`| Whether to write to InfluxDB |`true`|
+|`influxOutput.endpoint`| Database endpoint |`http://127.0.0.1:9999`|
+|`influxOutput.database`| Database name |`telegraf`|
+|`influxOutput.httpBasicAuth.enabled`| Whether http basic authentication is enabled |`false`|
+|`influxOutput.httpBasicAuth.username`| Database username |`telegraf`|
+|`influxOutput.httpBasicAuth.password`| Database password |`metrics`|
+

--- a/charts/telegraf/templates/_helpers.tpl
+++ b/charts/telegraf/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telegraf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telegraf.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telegraf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/telegraf/templates/configmap.yaml
+++ b/charts/telegraf/templates/configmap.yaml
@@ -1,0 +1,328 @@
+# Handles configuration of the Telegraf monitoring service. 
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-{{ .Values.Instance }}-configuration
+  labels:
+    app: {{ template "telegraf.name" . }}
+    chart: {{ template "telegraf.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
+
+# store Telegraf configuration file
+data:
+  "setup.sh": |-
+
+    #! /bin/bash 
+
+    mkdir -p /etc/telegraf/conf.d/
+
+    # Copy configuration file to proper location
+    cp /etc/setup/telegraf.conf  /etc/telegraf/conf.d/telegraf.conf
+
+    {{ if eq .Values.grnocOutput.enabled true }}
+    # Create edited configuration file
+    sed -e "s/passwordPlaceholder/$GRNOC_DATABASE_PASSWORD/" /etc/setup/config.yaml > /etc/telegraf/conf.d/config.yaml
+    {{ end }}
+
+
+  {{ if eq .Values.grnocOutput.enabled true }}
+
+  "config.yaml": |-
+
+    credentials:
+      url: {{ .Values.grnocOutput.hostname | quote }}
+      username: {{ .Values.grnocOutput.username }}
+      password: passwordPlaceholder
+
+    data:
+      - tsds_name: interface
+        telegraf_name: interface
+        interval: 60 # possibly make this configurable later if it's something that is necessary
+        metadata:
+          - from: agent_host
+            to: "node"
+          - from: ifName
+            to: "intf"
+        optional_metadata:
+          - from: ifAlias
+            to: description
+          # Take all the ip addresses and roll them up
+          - from: ip_address_*
+            to: interface_address
+            field_name: value
+        fields:
+          - from: ifInErrors
+            to: inerror
+            rate: true
+          - from: ifOutErrors
+            to: outerror
+            rate: true
+          - from: ifHCInOctets
+            to: input
+            rate: true
+          - from: ifHCOutOctets
+            to: output
+            rate: true
+          - from: ifHCInUcastPkts
+            to: inUcast
+            rate: true
+          - from: ifHCOutUcastPkts
+            to: outUcast
+            rate: true
+          - from: ifInDiscards
+            to: indiscard
+            rate: true
+          - from: ifOutDiscards
+            to: outdiscard
+            rate: true
+          - from: ifOperStatus
+            to: status
+
+  {{ end }}
+
+  "telegraf.conf": |-
+
+    # Tags that will be added to all Metrics
+    [global_tags]
+
+    # Telegraf Agent Config
+    [agent]
+      interval = {{ .Values.collectionInterval | quote }}
+      round_interval = true
+      metric_batch_size = 1000
+      metric_buffer_limit = 100000
+      collection_jitter = {{ .Values.collectionJitter | quote }}
+      flush_interval = {{ .Values.flushInterval | quote }}
+      flush_jitter = {{ .Values.flushJitter | quote }}
+      precision = ""
+
+
+    # Send telegraf metrics to stdout and file if enabled
+    {{ if eq .Values.writeToStdout true }}
+    [[outputs.file]]
+      files = ["stdout", "/tmp/metrics.out"]
+      data_format = "influx"
+    {{ end }}
+
+
+      # InfluxDB configuration
+    {{ if eq .Values.influxOutput.enabled true }}
+    [[outputs.influxdb]]
+      urls = [{{ .Values.influxOutput.endpoint | quote }}]
+      database = {{ .Values.influxOutput.database | quote }}
+
+      # Authentication, if enabled
+      {{ if eq .Values.influxOutput.httpBasicAuth.enabled true }}
+      username = {{ .Values.influxOutput.httpBasicAuth.username | quote }}
+      password = {{ .Values.influxOutput.httpBasicAuth.password | quote }}
+      {{ end }}
+
+    {{ end }}
+
+    # GlobalNOC database configuration
+    {{ if eq .Values.grnocOutput.enabled true }}
+    [[outputs.execd]]
+      namepass = ["interface"]
+      command = ["/usr/bin/python3", "/usr/bin/tsds-output.py", "/etc/telegraf/conf.d/config.yaml"]  
+      data_format = "json"
+      restart_delay = "10s"
+
+    {{ end }}
+
+
+    {{ if eq .Values.grnocOutput.enabled true }} 
+    [[processors.starlark]]
+    namepass = ["interface", "interface_address"]
+    source = '''
+    state = {}
+
+    def apply(metric):
+       #print("metric = %s" % metric) 
+
+       if "ifHCInOctets" in metric.fields:
+           metric.fields["ifHCInOctets"] *= 8
+       if "ifHCOutOctets" in metric.fields:
+           metric.fields["ifHCOutOctets"] *= 8
+
+       if "ifIndex" in metric.tags:
+           ipInfo = state.get(metric.tags["ifIndex"], [])
+           ipInfo = sorted(ipInfo, key = lambda x: x.tags["ipAdEntAddr"])
+
+           i = 0    
+           for result in ipInfo:    
+               value = result.tags["ipAdEntAddr"]
+               metric.tags["ip_address_%s" % i] = value
+               i += 1 
+
+       if "ipAdEntIfIndex" in metric.tags:
+           ifIndex = metric.tags["ipAdEntIfIndex"]
+           ip_list = state.setdefault(ifIndex, [])
+
+           ip_list = [x for x in ip_list if x.time > metric.time - (60*10)]
+
+           if not [x for x in ip_list if x.tags["ipAdEntAddr"] == metric.tags["ipAdEntAddr"]]:
+               ip_list.append(deepcopy(metric))
+
+           #print("STATE = %s" % ip_list)
+           state[ifIndex] = ip_list
+
+       return metric
+    '''
+    {{ end }}
+
+
+    # Loop through host groups to monitor.
+    {{ range .Values.targets }}
+
+    [[inputs.snmp]]
+
+      # Enumerate agent addresses to retrieve values from.
+      agents = [{{- range $value := .hostGroup.hosts }}
+      "{{ $value }}",
+      {{ end -}}]
+
+      timeout = {{ .hostGroup.timeout | quote }}
+      version = 2
+
+      # SNMP community string.
+      community = {{ .hostGroup.community | quote }}
+      # Number of retries to attempt.
+      retries = {{ .hostGroup.retries }}
+      max_repetitions = 15
+
+      # Poll custom OIDs if grnoc output is disabled.
+      {{ if eq $.Values.grnocOutput.enabled false }}
+      {{ .hostGroup.oids | indent 4 }}
+      {{ end }}
+
+      # Poll defined set of OIDs if grnoc output is enabled.
+      {{ if eq $.Values.grnocOutput.enabled true }}
+
+      # 64-bit counter OIDs
+      {{ if eq .hostGroup.counter64Bit true }}
+
+      [[inputs.snmp.table]]
+      name = "interface"
+      # inherit_tags = [ "source" ]
+        
+      [[inputs.snmp.table.field]]
+      oid = "IF-MIB::ifName"
+      name = "ifName"
+      is_tag = true
+
+      [[inputs.snmp.table.field]]
+      oid = "IF-MIB::ifDescr"
+      name = "ifDescr"
+      is_tag = true
+
+      [[inputs.snmp.table.field]]
+      oid = "IF-MIB::ifInErrors"
+      name = "ifInErrors"
+
+      [[inputs.snmp.table.field]]
+      oid = "IF-MIB::ifOutErrors"
+      name = "ifOutErrors"
+
+      [[inputs.snmp.table.field]]
+      oid = "IF-MIB::ifInDiscards"
+      name = "ifInDiscards"
+
+      [[inputs.snmp.table.field]]
+      oid = "IF-MIB::ifOutDiscards"
+      name = "ifOutDiscards"
+
+      [[inputs.snmp.table.field]]
+      name = "ifHCInOctets"
+      oid = "IF-MIB::ifHCInOctets" 
+       
+      [[inputs.snmp.table.field]]
+      name = "ifHCInUcastPkts"
+      oid = "IF-MIB::ifHCInUcastPkts" 
+       
+      [[inputs.snmp.table.field]]
+      name = "ifHCInMulticastPkts"
+      oid = "IF-MIB::ifHCInMulticastPkts" 
+        
+      [[inputs.snmp.table.field]]
+      name = "ifHCInBroadcastPkts"
+      oid = "IF-MIB::ifHCInBroadcastPkts"
+
+      [[inputs.snmp.table.field]]
+      name = "ifHCOutOctets"
+      oid = "IF-MIB::ifHCOutOctets"
+
+      [[inputs.snmp.table.field]]
+      name = "ifHCOutUcastPkts"
+      oid = "IF-MIB::ifHCOutUcastPkts"
+
+      [[inputs.snmp.table.field]]
+      name = "ifHCOutMulticastPkts"
+      oid = "IF-MIB::ifHCOutMulticastPkts"
+
+      [[inputs.snmp.table.field]]
+      name = "ifHCOutBroadcastPkts"
+      oid = "IF-MIB::ifHCOutBroadcastPkts"
+
+      [[inputs.snmp.table.field]]
+      name = "ifOperStatus"
+      oid = "IF-MIB::ifOperStatus"
+
+
+      [inputs.snmp.tagpass]
+        ifName = ["Vlan601","Vlan711", "Vlan710"]
+
+      {{ end }}
+
+
+      # 32-bit counter OIDs
+      {{ if eq .hostGroup.counter64Bit false }}
+
+      # Walk the ifXTable for counters, names, etc.
+      [[inputs.snmp.table]]
+        oid = "IF-MIB::ifXTable"
+        name = "interface"
+        inherit_tags = ["source"]
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifName"
+          name = "ifName"
+          is_tag = true
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifIndex"
+          name = "ifIndex"
+          is_tag = true
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifAlias"
+          name = "ifAlias"
+          is_tag = true
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifInErrors"
+          name = "ifInErrors"
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifOutErrors"
+          name = "ifOutErrors"
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifInDiscards"
+          name = "ifInDiscards"
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifOutDiscards"
+          name = "ifOutDiscards"
+
+        [[inputs.snmp.table.field]]
+          oid = "IF-MIB::ifOperStatus"
+          name = "ifOperStatus"
+
+      {{ end }}
+
+      {{ end }}
+
+    {{ end }}
+

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -1,0 +1,53 @@
+# Describes a Kubernetes deployment of a container running Telegraf.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "telegraf.fullname" . }}
+  labels:
+    app: {{ template "telegraf.name" . }}
+    chart: {{ template "telegraf.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
+    instanceID: {{ .Values.SLATE.Instance.ID | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "telegraf.name" . }}
+      instance: {{ .Values.Instance | quote }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "telegraf.name" . }}
+        chart: {{ template "telegraf.chart" . }}
+        instance: {{ .Values.Instance | quote }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: telegraf
+          image: karlnewell/tsds-telegraf
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /etc/setup/
+              name: telegraf-volume 
+          lifecycle:
+            postStart:
+              exec:
+                # This script will create the appropriate "config.yaml" file for the grnoc output plugin
+                command: ["/bin/bash", "/etc/setup/setup.sh"]
+          {{ if eq .Values.grnocOutput.enabled true }}
+          env:
+            - name: GRNOC_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.grnocOutput.passwordSecretName }}
+                  key: password
+          {{ end }}
+      volumes:
+        - name: telegraf-volume
+          # populate volume with config map data
+          configMap:
+            name: telegraf-{{ .Values.Instance }}-configuration
+

--- a/charts/telegraf/templates/deployment.yaml
+++ b/charts/telegraf/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: telegraf
-          image: karlnewell/tsds-telegraf
+          image: ghcr.io/globalnoc/tsds-telegraf
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /etc/setup/

--- a/charts/telegraf/templates/service.yaml
+++ b/charts/telegraf/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "telegraf.fullname" . }}
+  labels:
+    app: {{ template "telegraf.name" . }}
+    chart: {{ template "telegraf.chart" . }}
+    release: {{ .Release.Name }}
+    instance: {{ .Values.Instance | quote }}
+spec:
+  type: NodePort
+  ports:
+  - name: prometheus
+    port: 9126
+    targetPort: 9126
+    protocol: TCP
+  selector:
+    app: {{ template "telegraf.name" . }}
+    instance: {{ .Values.Instance | quote }}

--- a/charts/telegraf/values.yaml
+++ b/charts/telegraf/values.yaml
@@ -1,0 +1,100 @@
+# SLATE Telegraf Monitoring Configuration
+# More information about configuring and running this application can be found here:
+# https://slateci.io/blog/telegraf-monitoring.html
+
+
+# The slate instance value.
+Instance: ""
+
+# Optionally write metrics to stdout and local file in container.
+writeToStdout: true
+
+# Specifies the default data collection interval.
+# Time values can be specified by combining an integer value with a time unit.
+# Valid time units include "ns", "us", "ms", "s", "m" and "h".
+collectionInterval: "5s"
+# Specifies the random offset added to collection times
+collectionJitter: "10s"
+
+# Specifies time between output flushes.
+# Uses the same syntax as the interval parameter.
+flushInterval: "15s"
+# Specifies the random offset added to flush times
+flushJitter: "10s"
+
+
+# Configuration for GlobalNOC database output
+# Set enabled flag to true to enable GlobalNOC output.
+# Set hostname, and username accordingly.
+# Set passwordSecretName to the name of a previously created SLATE secret. (see README)
+# Note that enabling GRNOC output results in a pre-defined set of
+# OIDs being polled, and will override user-specified OIDs.
+grnocOutput:
+  enabled: true
+  hostname: "tsds.hostname.net"
+  username: "tsds username"
+  passwordSecretName: "tsds-password-secret"
+
+
+# Specify hosts to monitor here. Hosts can be IP addresses or DNS names.
+# A hostGroup is a group of hosts that share settings. (e.g. community string, oids, retries, and timeout)
+# The "timeout" parameter adjusts how long it takes before an SNMP request is considered failed.
+# Set this by specifying an integer and "s" afterwards, for seconds.
+# The "retries" parameter specifies how many retries to attempt in the case of a failed SNMP request.
+# Simply use an integer here.
+#
+# A port must also be specififed with a colon after hostname or address. (default is 161, and should probably not be changed)
+# Specify OIDs according to the Telegraf SNMP plugin format.
+# Documentation can be found at: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/snmp.
+# The counter64Bit parameter is only relevant if GRNOC output has been enabled.
+# The specified OIDs should take into account the counter type of the hosts to be monitored.
+#
+# GRNOC-specific configuration:
+# Enabling GRNOC database output results in a pre-configured set of OIDs being polled.
+# This means that the OIDs section will be ignored.
+# To poll from devices with 64-bit SNMP counters, set the counter64Bit paramter to true.
+# To poll from devices with 32-bit SNMP counters, set this parameter to false.
+targets:
+  - hostGroup:
+      community: "public"
+      timeout: "15s"
+      retries: 2
+      hosts:
+        - "127.0.0.1"
+      counter64Bit: false
+      oids: |-
+        [[inputs.snmp.field]]
+          oid = "DISMAN-EVENT-MIB::sysUpTimeInstance"
+          name = "uptime"
+  - hostGroup:
+      community: "public"
+      timeout: "15s"
+      retries: 2
+      hosts:
+        - "127.0.0.1"
+        - "localhost"
+      counter64Bit: true
+      oids: |-
+        [[inputs.snmp.field]]
+          oid = "DISMAN-EVENT-MIB::sysUpTimeInstance"
+          name = "uptime"
+
+
+# Configuration for InfluxDB (v1) output.
+# Set enabled flag to true to enable InfluxDB output.
+# Endpoint parameter must specify a protocol (udp or http) and a port.
+# Database parameter should be set to the database name.
+influxOutput:
+  enabled: false
+  endpoint: "http://127.0.0.1:9999"
+  database: "telegraf"
+  httpBasicAuth:
+    enabled: false
+    username: "telegraf"
+    password: "metrics"
+
+### SLATE-START ###
+SLATE:
+  Instance:
+    ID: "default-id"
+### SLATE-END ###


### PR DESCRIPTION
Closes #45 

This pull request migrates Telegraf from the [SLATE catalog](https://github.com/slateci/slate-catalog/tree/master/incubator/telegraf/telegraf) to the [SLATE catalog incubator](https://github.com/slateci/slate-catalog-incubator/tree/master/charts/telegraf) for production. 

The Docker image in telegraf/templates/deployment.yaml which comes from [karlnewell](https://github.com/karlnewell/tsds-telegraf) was marked as deprecated on its GitHub repo. The karlnewell repo suggested the [GlobalNOC](https://github.com/GlobalNOC/tsds-telegraf) repo be used instead. 

Joe confirmed with Dan that the GlobalNOC repo was up to date and most recent. I then got a go-ahead from Joe to switch the deprecated `karlnewell/tsds-telegraf` image for the up to date `globalnoc/tsds-telegraf` in deployment.yaml . 

I wasn't yet able to do any testing on this image due to my host platform (linux/arm64/v8) not matching the image's platform (linux/amd64). I hope to do the testing on the CHPC VM I hold. 